### PR TITLE
Cookies should expire in a session by default

### DIFF
--- a/example/auth_example.go
+++ b/example/auth_example.go
@@ -52,6 +52,12 @@ func main() {
 
 	m := martini.Classic()
 	m.Use(render.Renderer())
+
+	// Default our store to use Session cookies, so we don't leave logged in
+	// users roaming around
+	store.Options(sessions.Options{
+		MaxAge: 0,
+	})
 	m.Use(sessions.Sessions("my_session", store))
 	m.Use(sessionauth.SessionUser(GenerateAnonymousUser))
 	sessionauth.RedirectUrl = "/new-login"


### PR DESCRIPTION
Refs #8. While Remember Me functionality is should be setup using the session-contrib package, we should make sure our Cookies are Session cookies by default. Otherwise we can leave a logged in cookie on a user's computer (which could be in a public location or who knows where).
