### PR TITLE
Don't let the User object be responsible for talking to database

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,22 @@ Your user type should meet the login.User interface:
 
         // Return the unique identifier of this user object
         UniqueId() interface{}
-
-        // Populate this user object with values
-        GetById(id interface{}) error
    }
 ```
+
+There must be a function to retrieve the user from the database, with the following type:
+
+```go
+    type UserRetriever func(id interface{}) (User, error)
+```
+
 
 The SessionUser() Martini middleware will inject the login.User interface
 into your route handlers. These interfaces must be converted to your
 appropriate type to function correctly.
 
 ```go
-    func handler(user login.User, db *MyDB) {
+    func handler(user sessionauth.User, db *MyDB) {
         u := user.(*UserModel)
         db.Save(u)
     }

--- a/example/model/user.go
+++ b/example/model/user.go
@@ -1,4 +1,4 @@
-package main
+package model
 
 import (
 	"github.com/martini-contrib/sessionauth"
@@ -41,15 +41,4 @@ func (u *MyUserModel) IsAuthenticated() bool {
 
 func (u *MyUserModel) UniqueId() interface{} {
 	return u.Id
-}
-
-// GetById will populate a user object from a database model with
-// a matching id.
-func (u *MyUserModel) GetById(id interface{}) error {
-	err := dbmap.SelectOne(u, "SELECT * FROM users WHERE id = $1", id)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }


### PR DESCRIPTION
This commit is non-functional and therefore more like a suggestion than a request. The idea behind it is to let User.GetById go away and let the developer implement an external function to retrieve an User from the database. IMHO, it's something bad to let the model know the database.
