### PR TITLE
Don't return true from IsAuthenticated() on the first API access with…

### DIFF
--- a/sessionauth.go
+++ b/sessionauth.go
@@ -62,7 +62,7 @@ func SessionUser(newUser func() User) martini.Handler {
 			err := user.GetById(userId)
 			if err != nil {
 				l.Printf("Login Error: %v\n", err)
-			} else {
+			} else if !s.IsNew() {
 				user.Login()
 			}
 		}


### PR DESCRIPTION
… an expired session

This change is needed to avoid returning true from IsAuthenticated() on the first API access after a session is expired.
This was tested using yosssi/boltstore for session cookies, which correctly return the flag IsNew true from New() for an expired session.
However, it takes another round of middleware access for IsAuthenticated() to fail with the code before this change.
https://github.com/martini-contrib/sessionauth/issues/22
